### PR TITLE
add newer driver sources

### DIFF
--- a/DRIVERS/Z055_HDLC/DRIVER/driver.mak
+++ b/DRIVERS/Z055_HDLC/DRIVER/driver.mak
@@ -1,14 +1,17 @@
 #**************************  M a k e f i l e ********************************
 #
 #         Author: christian.schuster@men.de
-#          $Date: 2005/02/15 14:36:26 $
-#      $Revision: 1.1 $
+#          $Date: 2008/02/06 09:46:16 $
+#      $Revision: 1.2 $
 #
 #    Description: makefile descriptor for Toronto linux native driver
 #
 #---------------------------------[ History ]---------------------------------
 #
 # $Log: driver.mak,v $
+# Revision 1.2  2008/02/06 09:46:16  ts
+# changed module name to men_lx_z055 for conformity to other native drivers
+#
 # Revision 1.1  2005/02/15 14:36:26  cs
 # Initial Revision
 #
@@ -20,7 +23,7 @@
 #-----------------------------------------------------------------------------
 #   (c) Copyright 2004 by MEN mikro elektronik GmbH, Nuernberg, Germany
 #*****************************************************************************
-MAK_NAME=z055_hdlc
+MAK_NAME=lx_z055
 
 MAK_SWITCH=$(SW_PREFIX)MAC_MEM_MAPPED\
 
@@ -32,3 +35,27 @@ MAK_INCL=$(MEN_INC_DIR)/../../NATIVE/MEN/z055_hdlc.h     \
 MAK_INP1=z055_hdlc_drv$(INP_SUFFIX)
 
 MAK_INP=$(MAK_INP1)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/DRIVERS/Z055_HDLC/DRIVER/z055_hdlc_int.h
+++ b/DRIVERS/Z055_HDLC/DRIVER/z055_hdlc_int.h
@@ -3,19 +3,25 @@
  *        \file  z055_hdlc_int.h
  *
  *      \author  Christian.Schuster@men.de
- *        $Date: 2005/02/15 14:36:25 $
- *    $Revision: 1.1 $
+ *        $Date: 2010/12/22 15:52:32 $
+ *    $Revision: 1.2 $
  *
  *       \brief  Internal header file for Z055_HDLC linux driver
  *               containing driver internal defines, structures
  *
  *    \switches  none
  *
- * $Id: z055_hdlc_int.h,v 1.1 2005/02/15 14:36:25 cs Exp $
+ * $Id: z055_hdlc_int.h,v 1.2 2010/12/22 15:52:32 cs Exp $
  */
  /*-------------------------------[ History ]--------------------------------
  *
  * $Log: z055_hdlc_int.h,v $
+ * Revision 1.2  2010/12/22 15:52:32  cs
+ * R:1. new IP core versions support half duplex and coding NRZ-S
+ *   2. definition of the cores address size was confusing / too big
+ * M:1. register define for coding NRZI (NRZ-S) added
+ *   2. cleaned up and fixed Z055_ADDR_SIZE
+ *
  * Revision 1.1  2005/02/15 14:36:25  cs
  * Initial Revision
  *
@@ -40,15 +46,18 @@
 #define SYSTEM_CLOCK_FREQUENCY	33333333
 #define TX_SWITCH_BUFFERS		2
 
-#define Z055_REGISTER_EXTENT	0x003C	/* maximum value */
-#define Z055_RXBUF_EXTENT		0x800	/* 2kBytes */
-#define Z055_TXBUF_EXTENT		0x800	/* 2kBytes */
+#define Z055_ADDR_SIZE	0x2000		/**< mem size to request for device
+									  *  0x1000 for registers
+									  *  0x0800 RxBuf (2kBytes max)
+									  *  0x0800 TxBuf (2kBytes max)
+									  */
 
 
 #define BOOLEAN int
 #define TRUE 1
 #define FALSE 0
 
+/* The queue of BH actions to be performed */
 #define BH_RECEIVE  1
 #define BH_TRANSMIT 2
 #define BH_STATUS   4
@@ -200,18 +209,16 @@ struct Z055_STRUCT {
 #define Z055_BCH		0x000A	/* Baud Constant High Word (BCH) */
 #define Z055_BCR		0x000C	/* Baudrate Generator Control Register (BCR) */
 #define Z055_IER		0x0010	/* Interrupt Enable Register (IRER) */
-#define Z055_IRQR	0x0012	/* Interrupt Request Register (IRQR) */
-#define Z055_HSCR	0x0014	/* Handshake Control Register (HSCR) */
-#define Z055_HSSR	0x0016	/* Handshake Status Register (HSSR) */
-#define Z055_RES1	0x0018..0x001F	/* Reserved */
-#define Z055_TXSZR	0x0020	/* Tx Frame Size Register (TXSZR) */
-#define Z055_RXSZR	0x0022	/* Rx Frame Size Register (RXSZR) */
-#define Z055_RES2	0x003C-0x0FFF	/* Reserved */
-#define Z055_RXBUF	0x1000	/* Receive buffer (read only) */
-								/* default: 1 kB used (0xFFF) */
-#define Z055_TXBUF	0x1800	/* Transmit buffer (write only) */
-								/* default: 1 kB used (0xFFF) */
-
+#define Z055_IRQR		0x0012	/* Interrupt Request Register (IRQR) */
+#define Z055_HSCR		0x0014	/* Handshake Control Register (HSCR) */
+#define Z055_HSSR		0x0016	/* Handshake Status Register (HSSR) */
+#define Z055_RES1		0x0018..0x001F	/* Reserved */
+#define Z055_TXSZR		0x0020	/* Tx Frame Size Register (TXSZR) */
+#define Z055_RXSZR		0x0022	/* Rx Frame Size Register (RXSZR) */
+#define Z055_RES2		0x003C-0x0FFF	/* Reserved */
+#define Z055_RXBUF		0x1000	/* Receive buffer (read only) */
+#define Z055_TXBUF		0x1800	/* Transmit buffer (write only) */
+#define Z055_BUF_SIZE	0x0400	/* Buffer Size, default: 1 kB used (0xFFF) */
 /*
  * MACRO DEFINITIONS FOR HDLC CTRL REG
  */
@@ -234,7 +241,7 @@ struct Z055_STRUCT {
 
 #define Z055_HCR_TXIDLE		0x0040	/**< Transmitter state during idle */
 										/**<0: Tx sends flags during idle\n
-										 *  1: Tx sends marking ‘1’ during idle*/
+										 *  1: Tx sends marking Â‘1Â’ during idle*/
 
 #define Z055_HCR_SENDBRK		0x0020	/**< Send Abort */
 										/**<0: No abort is send\n
@@ -266,9 +273,10 @@ struct Z055_STRUCT {
 
 /** Setting of the Encoder and Decoder*/
 #define Z055_CDR_NRZ 		0x0000	/**< Set Rx/Tx to NRZ coded */
-#define Z055_CDR_NRZI 		0x0001	/**< Set Rx/Tx to NRZI coded */
+#define Z055_CDR_NRZI 		0x0001	/**< Set Rx/Tx to NRZI (NRZ-M) coded */
 #define Z055_CDR_MAN		0x0002	/**< Set Rx/Tx to Manchester coded */
-#define Z055_CDR_NRZI_MAN	0x0003	/**< Set Rx/Tx to NRZI–Manch. coded */
+#define Z055_CDR_NRZI_MAN	0x0003	/**< Set Rx/Tx to NRZIÂ–Manch. coded */
+#define Z055_CDR_NRZS	    0x0004	/**< Set Rx/Tx to NRZI (NRZ-S) coded */
 
 
 /*
@@ -448,11 +456,11 @@ struct Z055_STRUCT {
  * MACRO DEFINITIONS FOR HANDSHAKE CONTROL REGISTER
  */
 #define Z055_HSCR_RTS	0x0001		/**< RTS control */
-										/**<0: RTS is set to ‘0’\n
-										 *  1: RTS is set to ‘1’*/
+										/**<0: RTS is set to Â‘0Â’\n
+										 *  1: RTS is set to Â‘1Â’*/
 #define Z055_HSCR_DTR	0x0002		/**< DTR control */
-										/**<0: DTR is set to ‘0’\n
-										 *  1: DTR is set to ‘1’*/
+										/**<0: DTR is set to Â‘0Â’\n
+										 *  1: DTR is set to Â‘1Â’*/
 #define Z055_HSCR_HDX	0x0004		/**< Half duplex */
 										/**<0: Interface configured in full
 										 *     duplex\n
@@ -615,8 +623,6 @@ typedef unsigned MACCESS;         /* access pointer */
 
 #endif  /* _PPC_IO_H */
 
-#define Z055_ADDR_SIZE	0x3000		/* mem size to request for device */
-
 #define Z055_INREG(info, reg) 		MREAD_D16(info->ma_base + info->ma_offs, reg)
 #define Z055_OUTREG(info, reg, val)	MWRITE_D16(info->ma_base + info->ma_offs, reg, val)
 #define Z055_INRX(info, offs, len, buf) \
@@ -629,3 +635,4 @@ typedef unsigned MACCESS;         /* access pointer */
 
 
 #endif  /* _Z055_HDLC_INT_H_ */
+

--- a/INCLUDE/NATIVE/MEN/z055_hdlc.h
+++ b/INCLUDE/NATIVE/MEN/z055_hdlc.h
@@ -3,8 +3,8 @@
  *        \file  z055_hdlc.h
  *
  *      \author  Christian.Schuster@men.de
- *        $Date: 2005/02/15 14:36:30 $
- *    $Revision: 2.1 $
+ *        $Date: 2010/12/22 15:55:55 $
+ *    $Revision: 2.2 $
  *
  *       \brief  Header file for Z055_HDLC linux driver
  *               containing driver specific IOCTL codes,
@@ -13,11 +13,16 @@
  *
  *    \switches  none
  *
- * $Id: z055_hdlc.h,v 2.1 2005/02/15 14:36:30 cs Exp $
+ * $Id: z055_hdlc.h,v 2.2 2010/12/22 15:55:55 cs Exp $
  */
  /*-------------------------------[ History ]--------------------------------
  *
  * $Log: z055_hdlc.h,v $
+ * Revision 2.2  2010/12/22 15:55:55  cs
+ * R: 1. New IP core revisions support NRZ-S coding and half duplex
+ * M: 1a. Defines for setting NRZI (NRZ-S) coding added
+ *    1b. Defines for setting half/full duplex added
+ *
  * Revision 2.1  2005/02/15 14:36:30  cs
  * Initial Revision
  *
@@ -61,6 +66,7 @@
 #define HDLC_ENCODING_NRZI				1
 #define HDLC_ENCODING_MANCHESTER		2
 #define HDLC_ENCODING_MANCHESTER_NRZI	3
+#define HDLC_ENCODING_NRZI_S	        4
 
 //#define HDLC_PREAMBLE_LENGTH_8BITS	0
 //#define HDLC_PREAMBLE_LENGTH_16BITS	1
@@ -77,6 +83,9 @@
 #define Z055_MODE_HDLC		2
 
 #define Z055_BUS_TYPE_PCI	1
+
+#define HDLC_FULL_DUPLEX	0
+#define HDLC_HALF_DUPLEX	1
 
 typedef struct _Z055_PARAMS
 {
@@ -98,6 +107,7 @@ typedef struct _Z055_PARAMS
 								 * preset, return error frame */
 	unsigned char	preamble;	/* number of preambles to send */
 								/* preamble currently not supported */
+	unsigned char	half_duplex;    /* If 1, set half duplex; 0 set full duplex */
 
 } Z055_PARAMS, *PZ055_PARAMS;
 
@@ -190,3 +200,4 @@ struct Z055_ICOUNT {
 #define Z055_IOCWAITEVENT	_IOWR(Z055_MAGIC_IOC,8,int)
 
 #endif /* _Z55_DRV_H_ */
+


### PR DESCRIPTION
We found newer sources in our old MCVS, IMHO you should use these as base for porting the driver.