### PR TITLE
Unloading the driver doesn't clear the interrupts

### DIFF
--- a/DRIVERS/Z055_HDLC/DRIVER/z055_hdlc_drv.c
+++ b/DRIVERS/Z055_HDLC/DRIVER/z055_hdlc_drv.c
@@ -3448,6 +3448,30 @@ static void __exit z055_hdlc_exit(void)
 	int rc;
 	struct Z055_STRUCT *info;
 	struct Z055_STRUCT *tmp;
+	unsigned long flags;
+
+	info = G_z055_device_list;
+
+	printk( "%s(%d): shutting down %s; flags =%x\n",
+		__FUNCTION__, __LINE__, G_driver_name, info->flags);
+
+	spin_lock_irqsave(&info->irq_spinlock,flags);
+
+	z055_hw_DisableMasterIrqBit(info);
+	z055_hw_stop_receiver(info);
+	z055_hw_stop_transmitter(info);
+	z055_hw_DisableInterrupts(info, Z055_IER_RXINVEN   +
+					Z055_IER_RXABRTEN +
+					Z055_IER_RXFCSEEN +
+					Z055_IER_RXRCSTEN +
+					Z055_IER_RXBOVREN +
+					Z055_IER_RXBFLEN +
+                                        Z055_IER_TXBOVREN +
+					Z055_IER_TXBEPYEN +
+					Z055_IER_HSSEN );
+
+	spin_unlock_irqrestore(&info->irq_spinlock,flags);
+
 
 	printk( "%s(%d): Unloading %s: %s\n",
 			__FUNCTION__, __LINE__, G_driver_name,  IdentString);
@@ -3468,8 +3492,7 @@ static void __exit z055_hdlc_exit(void)
 	put_tty_driver(G_serial_driver);
 #endif
 	printk("%s(%d)\n", __FUNCTION__, __LINE__);
-
-	info = G_z055_device_list;
+	
 	while(info) {
 		z055_release_resources(info);
 		tmp = info;


### PR DESCRIPTION
When the user reboots and any other MDIS modules are loaded, 
if its interrupt is shared with other MDIS devices,
MDIS has then a connected handler to this IRQ, but no responding driver.
If a character is received at this time by the z055 controller, 
it issues an IRQ, which is handled by no one, leading to a freeze.