### PR TITLE
Ignore return type from tty_unregister_driver

### DIFF
--- a/DRIVERS/Z055_HDLC/DRIVER/z055_hdlc_drv.c
+++ b/DRIVERS/Z055_HDLC/DRIVER/z055_hdlc_drv.c
@@ -2919,13 +2919,7 @@ static void __exit z055_hdlc_exit(void)
 			__FUNCTION__, __LINE__,
 			G_serial_driver->driver_name, G_serial_driver->name);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
-	if ((rc = tty_unregister_driver(G_serial_driver)))
-		printk( "%s(%d): failed to unregister tty driver err=%d\n",
-				__FUNCTION__, __LINE__, rc);
-#else
 	tty_unregister_driver(G_serial_driver);
-#endif
 
 	printk("%s(%d)\n", __FUNCTION__, __LINE__);
 	tty_driver_kref_put(G_serial_driver);


### PR DESCRIPTION
This function was always returning 0 in older kernel versions and it ended up changing to void return type in newer kernel versions so let us just ignore the return of this so it would work with all kernel versions.

NOTE: This is the code from v4.9: https://elixir.bootlin.com/linux/v4.9/source/drivers/tty/tty_io.c